### PR TITLE
feat: change type of `table` parameter to `ITable`

### DIFF
--- a/API.md
+++ b/API.md
@@ -62,10 +62,10 @@ const tableViewerProps: TableViewerProps = { ... }
 ##### `table`<sup>Required</sup> <a name="cdk-dynamo-table-viewer.TableViewerProps.property.table"></a>
 
 ```typescript
-public readonly table: Table;
+public readonly table: ITable;
 ```
 
-- *Type:* [`aws-cdk-lib.aws_dynamodb.Table`](#aws-cdk-lib.aws_dynamodb.Table)
+- *Type:* [`aws-cdk-lib.aws_dynamodb.ITable`](#aws-cdk-lib.aws_dynamodb.ITable)
 
 The DynamoDB table to view.
 

--- a/src/table-viewer.ts
+++ b/src/table-viewer.ts
@@ -19,7 +19,7 @@ export interface TableViewerProps {
    * The DynamoDB table to view. Note that all contents of this table will be
    * visible to the public.
    */
-  readonly table: dynamodb.Table;
+  readonly table: dynamodb.ITable;
 
   /**
    * The web page title.


### PR DESCRIPTION
The current type of the passed in Dynamo table is `Table`. However, passing an `ITable` maintains the same behavior, but allows broader inputs.

With the introduction of `TableV2`/Global Tables in the dynamodb package, this change allows `TableV2` resources to be passed without workarounds. 